### PR TITLE
[Feat] 예약 내역이 없을 경우 UI

### DIFF
--- a/src/app/my-page/reservations/page.tsx
+++ b/src/app/my-page/reservations/page.tsx
@@ -56,13 +56,27 @@ export default function ReservationsTestPage() {
     },
   ] as const;
 
+  const hasData = testData.length > 0;
+
   return (
     <main className='bg-gray-50 min-h-screen flex flex-col items-center pt-[4.4rem]'>
-      <div className='w-full max-w-[600px] flex flex-col h-[calc(100vh-13.6rem)]'>
-        {testData.map((item, idx) => (
-          <ReservationsCard key={idx} {...item} />
-        ))}
-      </div>
+      {hasData ? (
+        <div className='w-full max-w-[600px] flex flex-col h-[calc(100vh-13.6rem)]'>
+          {testData.map((item, idx) => (
+            <ReservationsCard key={idx} {...item} />
+          ))}
+        </div>
+      ) : (
+        <div className='flex flex-col items-center justify-center h-[calc(100vh-13.6rem)]'>
+          <Image
+            src='/assets/icons/logo/ico-empty-view-logo.svg'
+            alt='빈 상태 이미지'
+            width={82}
+            height={123}
+          />
+          <p className='text-md text-gray-500 mt-[2.4rem]'>예약한 체험이 없다냥</p>
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
예약 내역이 없을 경우 UI 추가

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/b78f7a4d-1a46-409d-a1c2-ee58744b6775)

## 🛠️ 테스트 방법
1. my-page/reservations의 page.tsx에서 빈 데이터로 설정해두고 진행

## 🚧 관련 이슈
MEOW-132

## 💡 추가 정보
