### PR TITLE
[Fix] arrowbutton 사이즈 props 추가

### DIFF
--- a/src/app/test/button/page.tsx
+++ b/src/app/test/button/page.tsx
@@ -46,6 +46,10 @@ export default function ArrowButtonTestPage() {
             </div>
 
             <div className='text-center'>
+              <ArrowButton direction='right' size={30} onClick={() => handleClick('right')} />
+            </div>
+
+            <div className='text-center'>
               <ArrowButton
                 direction='down'
                 isOpen={isDropdownOpen}

--- a/src/components/common/buttons/ArrowButton.tsx
+++ b/src/components/common/buttons/ArrowButton.tsx
@@ -6,6 +6,7 @@ import ArrowIcon from '../icons/ArrowIcon';
 interface ArrowButtonProps {
   direction?: 'left' | 'right' | 'down';
   isOpen?: boolean;
+  size?: number;
   onClick?: MouseEventHandler<HTMLButtonElement>;
   className?: string;
 }
@@ -13,6 +14,7 @@ interface ArrowButtonProps {
 export default function ArrowButton({
   direction = 'left',
   isOpen = false,
+  size = 16,
   onClick,
   className = '',
   ...rest
@@ -29,11 +31,12 @@ export default function ArrowButton({
       onMouseEnter={() => hasHoverEffect && setIsHovered(true)}
       onMouseLeave={() => hasHoverEffect && setIsHovered(false)}
       aria-label={`${direction} 화살표 버튼`}
-      className={`p-2 transition-transform duration-200 ${getRotationClass}`}
+      className={`p-2 transition-transform duration-200 ${getRotationClass} ${className}`}
       {...rest}
     >
       <ArrowIcon
         direction={direction}
+        size={size}
         className={isHovered ? 'text-[#4B4B4B]' : 'text-[#A1A1A1]'}
       />
     </button>

--- a/src/components/common/icons/ArrowIcon.tsx
+++ b/src/components/common/icons/ArrowIcon.tsx
@@ -15,10 +15,16 @@ const ICONS = {
 
 interface ArrowIconProps extends SVGProps<SVGSVGElement> {
   direction: Direction;
+  size?: number;
   className?: string;
 }
 
-export default function ArrowIcon({ direction, className = '' }: ArrowIconProps) {
+export default function ArrowIcon({
+  direction,
+  size = 24,
+  className = '',
+  ...props
+}: ArrowIconProps) {
   const IconComponent = ICONS[direction];
-  return <IconComponent className={className} />;
+  return <IconComponent width={size} height={size} className={className} {...props} />;
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
`export default function ArrowButton({
  direction = 'left',
  isOpen = false,
  size = 16,
  onClick,
  className = '',
  ...rest
}: ArrowButtonProps)`

ArrowButton과 ArrowIcon에 size props가 추가되었습니다.

## 📸 스크린샷
![스크린샷 2025-06-03 오후 3 36 41](https://github.com/user-attachments/assets/81983b8a-39df-42e6-9ad4-3343c016f6e1)


## 🛠️ 테스트 방법

<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

1.
2.
3.

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->