### PR TITLE
[Feat] 예약 현황 캘린더 UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next": "15.3.2",
         "next-route": "^2.0.0",
         "react": "^19.0.0",
+        "react-calendar": "^6.0.0",
         "react-dom": "^19.0.0",
         "tailwindcss-animate": "^1.0.7",
         "tailwindcss-animated": "^2.0.0",
@@ -3605,6 +3606,15 @@
         "win32"
       ]
     },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-2.0.2.tgz",
+      "integrity": "sha512-Do66mSlSNifFFuo3l9gNKfRMSFi26CRuQMsDJuuKO/ekrDWuTTtE4ZQxoFCUOG+NgxnpSeBq/k5TY8ZseEzLpA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -5772,6 +5782,18 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-3.0.0.tgz",
+      "integrity": "sha512-iJfHSmdYV39UUBw7Jq6GJzeJxUr4U+S03qdhVuDsR9gCEnfbqLy9gYDJFBJQL1riqolFUKQvx36mEkp2iGgJ3g==",
+      "license": "MIT",
+      "dependencies": {
+        "memoize": "^10.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -6516,7 +6538,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6698,7 +6719,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6744,6 +6764,21 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/memoize": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
+      "integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/meowhere": {
       "resolved": "",
       "link": true
@@ -6768,6 +6803,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -7563,6 +7610,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-6.0.0.tgz",
+      "integrity": "sha512-6wqaki3Us0DNDjZDr0DYIzhSFprNoy4FdPT9Pjy5aD2hJJVjtJwmdMT9VmrTUo949nlk35BOxehThxX62RkuRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^2.0.2",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^3.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {
@@ -9018,6 +9090,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "15.3.2",
     "next-route": "^2.0.0",
     "react": "^19.0.0",
+    "react-calendar": "^6.0.0",
     "react-dom": "^19.0.0",
     "tailwindcss-animate": "^1.0.7",
     "tailwindcss-animated": "^2.0.0",

--- a/src/app/profile/my-reservations/components/ReservationCalendar.tsx
+++ b/src/app/profile/my-reservations/components/ReservationCalendar.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import Calendar from 'react-calendar';
+import '@/src/styles/reservation-calendar.css';
+
+import type {
+  StatusData,
+  ReservationCalendarProps,
+  TileClassNameArgs,
+} from '../../../../types/my-reservation-calendar.types';
+
+// 공통 스타일 적용을 위한 상태 매핑 객체
+const STATUS_STYLE_MAP = {
+  pending: {
+    label: '예약',
+    colorClass: 'text-green-200 bg-green-100',
+  },
+  confirmed: {
+    label: '승인',
+    colorClass: 'text-blue-200 bg-blue-100',
+  },
+  declined: {
+    label: '거절',
+    colorClass: 'text-gray-600 bg-gray-100',
+  },
+};
+
+export default function ReservationCalendar({ statusData }: ReservationCalendarProps) {
+  const [value, setValue] = useState<Date>(new Date());
+
+  // 상태별 표시 content 구성
+  const tileContent = ({ date }: { date: Date }) => {
+    const dateStr = date.toISOString().slice(0, 10);
+    const info = statusData.find((d) => d.date === dateStr);
+    if (!info) return null;
+
+    const items = [
+      { key: 'pending', count: info.pendingCount },
+      { key: 'confirmed', count: info.confirmedCount },
+      { key: 'declined', count: info.declinedCount },
+    ] as const;
+
+    const contents = items.flatMap(({ key, count }) =>
+      count > 0
+        ? [
+            <div
+              key={key}
+              className={`w-full h-[16px] flex items-center justify-center text-center rounded-full text-[0.9rem] leading-auto font-medium ${STATUS_STYLE_MAP[key as keyof typeof STATUS_STYLE_MAP].colorClass}`}
+            >
+              {`${STATUS_STYLE_MAP[key as keyof typeof STATUS_STYLE_MAP].label} ${count}`}
+            </div>,
+          ]
+        : []
+    );
+
+    if (contents.length === 0) return null;
+
+    return (
+      <div className='flex flex-col bottom-[10px] left-0 right-0 px-1 text-center text-xs font-medium gap-[2px]'>
+        {contents}
+      </div>
+    );
+  };
+
+  const tileClassName = ({
+    date,
+    view,
+    activeStartDate,
+  }: {
+    date: Date;
+    view: string;
+    activeStartDate: Date;
+  }) => {
+    const currentMonth = activeStartDate.getMonth();
+    const isSameMonth = date.getMonth() === currentMonth;
+    const day = date.getDay();
+
+    const base = 'flex flex-col min-h-[86px] pt-[10px] pb-[8px] text-[1.1rem] font-semibold';
+
+    if (!isSameMonth) return `${base} text-gray-400 opacity-40`;
+    if (day === 0) return `${base} text-red-300`;
+    if (day === 6) return `${base} text-blue-300`;
+    return `${base} text-gray-600`;
+  };
+
+  return (
+    <div className='mx-auto min-w-[327px] w-full'>
+      <Calendar
+        locale='ko-KR'
+        calendarType='gregory'
+        formatDay={(_, date) => String(date.getDate())}
+        next2Label={null}
+        prev2Label={null}
+        value={value}
+        onChange={(nextValue) => {
+          if (nextValue instanceof Date) setValue(nextValue);
+          else if (Array.isArray(nextValue) && nextValue[0] instanceof Date) setValue(nextValue[0]);
+        }}
+        tileContent={tileContent}
+        tileClassName={tileClassName}
+      />
+    </div>
+  );
+}

--- a/src/app/profile/my-reservations/page.tsx
+++ b/src/app/profile/my-reservations/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import ReservationCalendar from '../my-reservations/components/ReservationCalendar';
+
+// 임시데이터
+const sampleData = [
+  { date: '2025-05-01', pendingCount: 2, confirmedCount: 1, declinedCount: 3 },
+  { date: '2025-05-03', pendingCount: 0, confirmedCount: 2, declinedCount: 1 },
+  { date: '2025-05-10', pendingCount: 1, confirmedCount: 0, declinedCount: 0 },
+  { date: '2025-05-15', pendingCount: 3, confirmedCount: 2, declinedCount: 0 },
+  { date: '2025-05-28', pendingCount: 0, confirmedCount: 0, declinedCount: 5 },
+  { date: '2025-06-05', pendingCount: 1, confirmedCount: 0, declinedCount: 5 },
+  { date: '2025-06-08', pendingCount: 1, confirmedCount: 2, declinedCount: 5 },
+  { date: '2025-06-09', pendingCount: 1, confirmedCount: 2, declinedCount: 0 },
+];
+
+export default function ReservationTestPage() {
+  return (
+    <main className='min-h-screen bg-white px-[20px] pt-[176px] flex justify-center items-start'>
+      <div className='w-full max-w-[745px] mx-auto bg-white'>
+        <ReservationCalendar statusData={sampleData} />
+      </div>
+    </main>
+  );
+}

--- a/src/styles/reservation-calendar.css
+++ b/src/styles/reservation-calendar.css
@@ -1,0 +1,67 @@
+.react-calendar {
+  border: none;
+  width: 100%;
+  font-family: 'Pretendard', sans-serif;
+}
+
+.react-calendar__navigation {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 500px;
+  margin-bottom: 20px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.react-calendar__navigation button {
+  width: 24px;
+  height: 24px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  background: none;
+  border: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2.2rem; /* 화살표 높이 기준 */
+  font-weight: 600;
+  color: #4b4b4b; /* 화살표 컬러 */
+  line-height: 1;
+}
+
+.react-calendar__viewContainer {
+  max-width: 745px;
+  margin: 0 auto;
+}
+
+.react-calendar__month-view__weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  border-bottom: 1px solid #f4f3f2; /* gray-100 */
+  padding: 5.5px 0;
+}
+
+.react-calendar__month-view__weekdays abbr {
+  text-decoration: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  font-size: 1.1rem;
+  font-weight: 600; /* semibold */
+  line-height: normal; /* auto (기본) */
+  letter-spacing: -2.5%; /* -0.0275em */
+  color: #6e625a; /* gray-600 */
+}
+.react-calendar__month-view__weekdays__weekday:nth-child(1) abbr {
+  color: #ff472e; /* red-300 */
+}
+
+.react-calendar__month-view__weekdays__weekday:nth-child(7) abbr {
+  color: #0051ff; /* blue-200 */
+}
+
+.react-calendar__tile {
+  min-width: 47px;
+}

--- a/src/types/my-reservation-calendar.types.ts
+++ b/src/types/my-reservation-calendar.types.ts
@@ -1,0 +1,28 @@
+// 'pending' = 예약, 'confirmed' = 승인, 'declined' = 거절 (API 명세 기반)
+export type ReservationStatusKey = 'pending' | 'confirmed' | 'declined';
+
+// 해당 날짜에 발생한 예약, 승인, 거절의 건수
+export interface StatusData {
+  date: string;
+  pendingCount: number;
+  confirmedCount: number;
+  declinedCount: number;
+}
+
+// 달력에 표시되는 예약 상태 데이터 배열
+export interface ReservationCalendarProps {
+  statusData: StatusData[];
+}
+
+// 날짜 셀 스타일 지정을 위한 react-calendar tileClassName 인자 타입
+export interface TileClassNameArgs {
+  date: Date;
+  view: string;
+  activeStartDate: Date;
+}
+
+// 예약 상태별 텍스트(label)와 Tailwind 색상 클래스(colorClass) 정의 타입
+export interface StatusStyle {
+  label: string;
+  colorClass: string;
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
예약 현황 캘린더 UI 커스터마이징 및 반응형 처리

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/f77156e5-79ed-4bd2-8082-f9f31e7f5bff)
모바일
![image](https://github.com/user-attachments/assets/bda8472f-a703-4535-acf2-cf5c81699f3a)
태블릿
![image](https://github.com/user-attachments/assets/cebf5cfd-ae74-4af4-87e4-2683cbd06aa1)
PC

## 🛠️ 테스트 방법
1. profile/my-reservations 페이지 이동 후 확인 가능

## 🚧 관련 이슈
MEOW-164

## 💡 추가 정보
- 날짜 부분은 tailwind로 커스터마이징이 가능하나, 기본적인 연도/월과 화살표의 경우, 기본 css를 활용해야하므로 stlyes 폴더에서 작업
- 디자인 관련
  - 화살표는 text 형태로 기본 제공
  - 요일과 날짜 폰트 사이즈가 지정이 되어있지 않아, 1.1rem로 설정
  - 모바일 아이폰 SE의 경우 padding 24px이면 토요일이 짤려보이는 현상으로  padding 20px로 변경
  - 해당 달의 날짜가 아닌 날짜는 투명도 주어서 회색 처리
- 공휴일 처리를 하게 되면 red로 할 계획인데, 공공데이터 API를 사용해야하므로 논의 필요