### PR TITLE
[Feat] 로그인 및 회원가입 쿼리훅과 상태관리 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.77.2",
+        "@tanstack/react-query-devtools": "^5.80.5",
         "clsx": "^2.1.1",
         "framer-motion": "^12.15.0",
         "meowhere": "file:",
@@ -2970,9 +2971,19 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.79.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.79.0.tgz",
-      "integrity": "sha512-s+epTqqLM0/TbJzMAK7OEhZIzh63P9sWz5HEFc5XHL4FvKQXQkcjI8F3nee+H/xVVn7mrP610nVXwOytTSYd0w==",
+      "version": "5.80.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.5.tgz",
+      "integrity": "sha512-kFWXdQOUcjL/Ugk3GrI9eMuG3DsKBGaLIgyOLekR2UOrRrJgkLgPUNzZ10i8FCkfi4SgLABhOtQhx1HjoB9EZQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.80.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.80.0.tgz",
+      "integrity": "sha512-D6gH4asyjaoXrCOt5vG5Og/YSj0D/TxwNQgtLJIgWbhbWCC/emu2E92EFoVHh4ppVWg1qT2gKHvKyQBEFZhCuA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2980,18 +2991,35 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.79.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.79.0.tgz",
-      "integrity": "sha512-DjC4JIYZnYzxaTzbg3osOU63VNLP67dOrWet2cZvXgmgwAXNxfS52AMq86M5++ILuzW+BqTUEVMTjhrZ7/XBuA==",
+      "version": "5.80.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.80.5.tgz",
+      "integrity": "sha512-C0d+pvIahk6fJK5bXxyf36r9Ft6R9O0mwl781CjBrYGRJc76XRJcKhkVpxIo68cjMy3i47gd4O1EGooAke/OCQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.79.0"
+        "@tanstack/query-core": "5.80.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.80.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.80.5.tgz",
+      "integrity": "sha512-+amzmlESL7e02Le28mEE8W5oiK5j/N/lBWu/dO3IbrD24SlP8cnfvYMMWTxLVkqZ9DJWEB3BqML8snAovl03uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.80.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.80.5",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.77.2",
+    "@tanstack/react-query-devtools": "^5.80.5",
     "clsx": "^2.1.1",
     "framer-motion": "^12.15.0",
     "meowhere": "file:",

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -11,6 +11,7 @@ export default function Account() {
       <div className='w-full md:max-w-[480px] border-2 p-[24px] rounded-[20px]'>
         <AuthModal />
       </div>
+      {/* 테스트 모달 */}
       <div className='absolute top-40'>
         <BaseButton onClick={openAuthModal}>테스트 로그인 모달</BaseButton>
       </div>

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,0 +1,19 @@
+'use client';
+import BaseButton from '@/src/components/common/buttons/BaseButton';
+import AuthModal from '@/src/components/common/modals/AuthModal';
+import { useModal } from '@/src/hooks/useModal';
+
+export default function Account() {
+  const { openAuthModal } = useModal();
+
+  return (
+    <div className='min-h-screen flex flex-col items-center justify-center text-lg p-[16px]'>
+      <div className='w-full md:max-w-[480px] border-2 p-[24px] rounded-[20px]'>
+        <AuthModal />
+      </div>
+      <div className='absolute top-40'>
+        <BaseButton onClick={openAuthModal}>테스트 로그인 모달</BaseButton>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  const authCookies = ['accessToken', 'refreshToken'];
+
+  const response = NextResponse.json(
+    {
+      message: '로그아웃 성공',
+    },
+    { status: 200 }
+  );
+
+  authCookies.forEach((cookieName) => {
+    response.cookies.set(cookieName, '', {
+      expires: new Date(0),
+      path: '/',
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+    });
+  });
+
+  return response;
+}

--- a/src/app/test/route/auth/page.tsx
+++ b/src/app/test/route/auth/page.tsx
@@ -1,87 +1,84 @@
 'use client';
 
+import BaseButton from '@/src/components/common/buttons/BaseButton';
+import { useLogin, useLogout, useSignUp, useUser } from '@/src/hooks/auth/useAuth';
+import { useAuthStore } from '@/src/store/authStore';
+import { checkEmailExistence } from '@/src/utils/checkEmailExistence';
 import { useEffect, useState } from 'react';
-import { BASE_URL } from '@/src/constants/api';
+
+const loginFormData = {
+  email: 'yhk8462@naver.com',
+  password: 'password123',
+};
+
+const signUpFormData = {
+  email: 'test111@test.com',
+  password: 'password123',
+  nickname: 'test user',
+};
 
 export default function AuthTest() {
-  const [loginData, setLoginData] = useState(null);
-  const [tokenRefreshData, setTokenRefreshData] = useState(null);
-  const [error, setError] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const { user } = useAuthStore();
+  const [isUser, setIsUser] = useState<boolean | null>(null);
+  const loginMutation = useLogin();
+  const logoutMutation = useLogout();
+  const signUpMutation = useSignUp();
+  const { data, isLoading, isError, refetch } = useUser();
 
-  // 로그인 및 토큰 갱신 로직을 useEffect 안으로 이동
+  const handleCheckIfUser = async () => {
+    const result = await checkEmailExistence('yhk8462@naver.com');
+    console.log(result);
+    setIsUser(result);
+  };
+
+  const handleLogin = async () => {
+    const result = await loginMutation.mutateAsync(loginFormData);
+    console.log(result);
+  };
+
+  const handleSignUp = async () => {
+    const result = await signUpMutation.mutateAsync(signUpFormData);
+    console.log(result);
+  };
+
+  const handleFetchUser = async () => {
+    refetch();
+  };
+
+  const handleLogout = () => {
+    logoutMutation.mutate();
+  };
+
   useEffect(() => {
-    const performAuthOperations = async () => {
-      try {
-        setLoading(true);
-
-        // 1. 로그인
-        const formData = {
-          email: 'yhk8462@naver.com',
-          password: 'password123',
-        };
-        const login = async (formData: any) => {
-          const res = await fetch(`${BASE_URL}/api/auth/login`, {
-            method: 'POST',
-            body: JSON.stringify(formData),
-            credentials: 'include', // 브라우저 쿠키를 포함
-            headers: {
-              'Content-Type': 'application/json', // JSON 바디를 보내므로 헤더 명시
-            },
-          });
-          if (!res.ok) {
-            const errorData = await res.json().catch(() => ({ message: '로그인 실패' }));
-            throw new Error(errorData.message || '로그인 실패');
-          }
-          return res.json();
-        };
-
-        const loginRes = await login(formData);
-        setLoginData(loginRes);
-        console.log('로그인 성공:', loginRes);
-
-        // 2. 토큰 갱신
-        // const refreshToken = async () => {
-        //   const res = await fetch(`${BASE_URL}/api/auth/tokens`, {
-        //     method: 'POST',
-        //     credentials: 'include',
-        //   });
-        //   if (!res.ok) {
-        //     const errorData = await res.json().catch(() => ({ message: '토큰 갱신 실패' }));
-        //     throw new Error(errorData.message || '토큰 갱신 실패');
-        //   }
-        //   return res.json();
-        // };
-
-        // const tokenRes = await refreshToken();
-        // setTokenRefreshData(tokenRes);
-        // console.log('토큰 갱신 성공:', tokenRes);
-      } catch (err: any) {
-        setError(err.message || '알 수 없는 오류 발생');
-        console.error('인증 작업 중 오류 발생:', err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    performAuthOperations();
-  }, []);
-
-  if (loading) {
-    return <div>로딩 중...</div>;
-  }
-
-  if (error) {
-    return <div>오류: {error}</div>;
-  }
+    console.log('AuthStore user:', user);
+    console.log('Query data:', data);
+  }, [user, data]);
 
   return (
-    <div className='text-xl'>
-      <h1>Auth API Test Page</h1>
-      <h2>로그인 결과:</h2>
-      <pre>{JSON.stringify(loginData, null, 2)}</pre>
-      {/* <h2>토큰 갱신 결과:</h2>
-      <pre>{JSON.stringify(tokenRefreshData, null, 2)}</pre> */}
+    <div className='flex flex-col items-center justify-center min-h-screen gap-[16px]'>
+      <h1>Auth Query API Test Page</h1>
+      <div className='flex gap-[16px]'>
+        <div className='flex'>
+          <BaseButton onClick={handleLogin}>로그인</BaseButton>
+        </div>
+        <div className='flex'>
+          <BaseButton onClick={handleSignUp}>회원가입</BaseButton>
+        </div>
+        <div className='flex'>
+          <BaseButton onClick={handleCheckIfUser}>이메일 검증</BaseButton>
+        </div>
+        <div className='flex'>
+          <BaseButton onClick={handleFetchUser}>사용자 정보</BaseButton>
+        </div>
+        <div className='flex'>
+          <BaseButton onClick={handleLogout}>로그아웃</BaseButton>
+        </div>
+      </div>
+      <div>로그인 리스폰스: {user && user.nickname}</div>
+      <div>회원가입 리스폰스:</div>
+      <div>
+        이메일 검증 리스폰스: {isUser === true ? 'true' : isUser === false ? 'false' : 'null'}
+      </div>
     </div>
   );
 }

--- a/src/app/test/route/auth/page.tsx
+++ b/src/app/test/route/auth/page.tsx
@@ -24,6 +24,7 @@ export default function AuthTest() {
   const logoutMutation = useLogout();
   const { signUpAndLogin } = useSignUp();
   const { data, isLoading, isError, refetch } = useUser();
+  const [signUpResult, setSignUpResult] = useState({});
 
   const handleCheckIfUser = async () => {
     const result = await checkEmailExistence('yhk8462@naver.com');
@@ -39,6 +40,7 @@ export default function AuthTest() {
   const handleSignUp = async () => {
     const result = await signUpAndLogin(signUpFormData);
     console.log(result);
+    setSignUpResult(result);
   };
 
   const handleFetchUser = async () => {
@@ -52,6 +54,7 @@ export default function AuthTest() {
   useEffect(() => {
     console.log('AuthStore user:', user);
     console.log('Query data:', data);
+    console.log('error:');
   }, [user, data]);
 
   return (
@@ -75,7 +78,7 @@ export default function AuthTest() {
         </div>
       </div>
       <div>로그인 리스폰스: {user && user.nickname}</div>
-      <div>회원가입 리스폰스:</div>
+      <div>회원가입 리스폰스: {JSON.stringify(signUpResult)}</div>
       <div>
         이메일 검증 리스폰스: {isUser === true ? 'true' : isUser === false ? 'false' : 'null'}
       </div>

--- a/src/app/test/route/auth/page.tsx
+++ b/src/app/test/route/auth/page.tsx
@@ -28,7 +28,7 @@ export default function AuthTest() {
 
   const handleCheckIfUser = async () => {
     const result = await checkEmailExistence('yhk8462@naver.com');
-    console.log(result);
+    console.log('email:', result);
     setIsUser(result);
   };
 

--- a/src/app/test/route/auth/page.tsx
+++ b/src/app/test/route/auth/page.tsx
@@ -54,8 +54,8 @@ export default function AuthTest() {
   useEffect(() => {
     console.log('AuthStore user:', user);
     console.log('Query data:', data);
-    console.log('error:');
-  }, [user, data]);
+    console.log('error:', isError);
+  }, [user, data, isError]);
 
   return (
     <div className='flex flex-col items-center justify-center min-h-screen gap-[16px]'>

--- a/src/app/test/route/auth/page.tsx
+++ b/src/app/test/route/auth/page.tsx
@@ -12,7 +12,7 @@ const loginFormData = {
 };
 
 const signUpFormData = {
-  email: 'test111@test.com',
+  email: 'test117@test.com',
   password: 'password123',
   nickname: 'test user',
 };
@@ -22,7 +22,7 @@ export default function AuthTest() {
   const [isUser, setIsUser] = useState<boolean | null>(null);
   const loginMutation = useLogin();
   const logoutMutation = useLogout();
-  const signUpMutation = useSignUp();
+  const { signUpAndLogin } = useSignUp();
   const { data, isLoading, isError, refetch } = useUser();
 
   const handleCheckIfUser = async () => {
@@ -37,7 +37,7 @@ export default function AuthTest() {
   };
 
   const handleSignUp = async () => {
-    const result = await signUpMutation.mutateAsync(signUpFormData);
+    const result = await signUpAndLogin(signUpFormData);
     console.log(result);
   };
 

--- a/src/components/common/buttons/KakaoLoginButton.tsx
+++ b/src/components/common/buttons/KakaoLoginButton.tsx
@@ -16,7 +16,7 @@ export default function KakaoLoginButton({
     <button
       type='button'
       onClick={onClick}
-      className={`relative w-[25rem] h-[3rem] px-4 border rounded-[0.625rem] text-gray-600 border-gray-400 font-medium text-center w-ful ${className}`}
+      className={`relative h-[3rem] px-4 border rounded-[0.625rem] text-gray-600 font-medium text-center w-full ${className}`}
       aria-label='카카오 로그인'
       {...rest}
     >

--- a/src/components/common/modals/AuthModal.tsx
+++ b/src/components/common/modals/AuthModal.tsx
@@ -1,3 +1,42 @@
+import { useModal } from '@/src/hooks/useModal';
+import CloseButton from '../buttons/CloseButton';
+import Input from '../inputs/Input';
+import BaseButton from '../buttons/BaseButton';
+import KakaoLoginButton from '../buttons/KakaoLoginButton';
+import { useState } from 'react';
+
+const header = {
+  login: '로그인',
+  signup: '회원가입',
+  default: '로그인 및 회원가입',
+};
+
 export default function AuthModal() {
-  return <div>회원 가입 및 로그인</div>;
+  const { closeModal } = useModal();
+  const [formType, setFormType] = useState();
+  const [title, setTitle] = useState(header.default);
+
+  const handleKakaoLogin = () => {
+    console.log('카카오');
+  };
+
+  return (
+    <div className='relative'>
+      {/* Header */}
+      <div className='flex items-center justify-center mb-[48px]'>
+        {title}
+        <div className='absolute right-0'>
+          <CloseButton size='sm' onClick={closeModal} />
+        </div>
+      </div>
+      {/* Form */}
+      <form>
+        <Input label='이메일' type='email' />
+        <div className='flex flex-col gap-[16px] mt-[60px]'>
+          <BaseButton>계속</BaseButton>
+          <KakaoLoginButton onClick={handleKakaoLogin} className='h-[48px]'></KakaoLoginButton>
+        </div>
+      </form>
+    </div>
+  );
 }

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -1,0 +1,85 @@
+import { authApi } from '@/src/services/authApi';
+import { useAuthStore } from '@/src/store/authStore';
+import { User, UserResponse } from '@/src/types/user.types';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+export const useLogin = () => {
+  const queryClient = useQueryClient();
+  const { setUser } = useAuthStore();
+
+  return useMutation({
+    mutationFn: authApi.login,
+    onSuccess: (data) => {
+      if (data.user && !data.error) {
+        setUser(data.user);
+        queryClient.invalidateQueries({ queryKey: ['user'] });
+      }
+    },
+    onError: (error) => {
+      console.log('로그인 실패:', error);
+    },
+  });
+};
+
+export const useSignUp = () => {
+  const queryClient = useQueryClient();
+  const { setUser } = useAuthStore();
+
+  return useMutation({
+    mutationFn: authApi.signUp,
+    onSuccess: (data) => {
+      if (data.user && !data.error) {
+        setUser(data.user);
+        queryClient.invalidateQueries({ queryKey: ['user'] });
+      }
+    },
+    onError: (error) => {
+      console.log('회원가입 실패:', error);
+    },
+  });
+};
+
+export const useUser = () => {
+  const { setUser, setLoading } = useAuthStore();
+
+  const query = useQuery({
+    queryKey: ['user'],
+    queryFn: authApi.getMe,
+    retry: 1,
+    staleTime: 5 * 60 * 1000, // 5분
+    refetchOnWindowFocus: false,
+  });
+
+  useEffect(() => {
+    if (query.isSuccess) {
+      if (query.data && !query.error) {
+        setUser(query.data);
+      } else {
+        setUser(null);
+      }
+      setLoading(false);
+    }
+
+    if (query.isError) {
+      console.error('사용자 정보 조회 실패:', query.error);
+      setUser(null);
+      setLoading(false);
+    }
+  }, [query.isSuccess, query.isError, query.data, query.error, setUser, setLoading]);
+
+  return query;
+};
+
+export const useLogout = () => {
+  const queryClient = useQueryClient();
+  const { logout } = useAuthStore();
+
+  return useMutation({
+    mutationFn: authApi.logout,
+    onSuccess: () => {
+      logout();
+      queryClient.clear();
+    },
+  });
+};

--- a/src/lib/fetch/fetchFromClient.ts
+++ b/src/lib/fetch/fetchFromClient.ts
@@ -1,6 +1,10 @@
 import { BASE_URL } from '@/src/constants/api';
 import { logger } from '@/src/utils/logger';
 
+export interface HttpError extends Error {
+  status?: number;
+}
+
 export async function fetchFromClient(path: string, options: RequestInit = {}): Promise<Response> {
   try {
     const res = await fetch(`${BASE_URL}/api/${path}`, {
@@ -9,7 +13,9 @@ export async function fetchFromClient(path: string, options: RequestInit = {}): 
     });
     if (!res.ok) {
       const errorData = await res.json().catch(() => ({}));
-      throw new Error(errorData.message || `HTTP error: ${res.status}`);
+      const error: HttpError = new Error(errorData.message || `HTTP error: ${res.status}`);
+      error.status = res.status;
+      throw error;
     }
     return res;
   } catch (error) {

--- a/src/lib/fetch/fetchFromClient.ts
+++ b/src/lib/fetch/fetchFromClient.ts
@@ -7,6 +7,10 @@ export async function fetchFromClient(path: string, options: RequestInit = {}): 
       ...options,
       credentials: 'include',
     });
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({}));
+      throw new Error(errorData.message || `HTTP error: ${res.status}`);
+    }
     return res;
   } catch (error) {
     logger.error('fetchFromClient error:', error);

--- a/src/lib/react-query/ReactQueryProvider.tsx
+++ b/src/lib/react-query/ReactQueryProvider.tsx
@@ -1,8 +1,9 @@
-"use client";
+'use client';
 
-import { ReactNode } from "react";
-import { QueryClientProvider } from "@tanstack/react-query";
-import { queryClient } from "./queryClient";
+import { ReactNode } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from './queryClient';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 interface Props {
   children: ReactNode;
@@ -10,6 +11,9 @@ interface Props {
 
 export default function ReactQueryProvider({ children }: Props) {
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
   );
 }

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -20,7 +20,7 @@ export const authApi = {
     return res.json();
   },
 
-  signUp: async (credentials: SignUpRequest) => {
+  signUp: async (credentials: SignUpRequest): Promise<User> => {
     const res = await fetchFromClient('/users', {
       method: 'POST',
       credentials: 'include',

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -17,6 +17,7 @@ export const authApi = {
       method: 'GET',
       credentials: 'include',
     });
+
     return res.json();
   },
 

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -1,0 +1,40 @@
+import { fetchFromClient } from '../lib/fetch/fetchFromClient';
+import { LoginRequest, LoginResponse, SignUpRequest } from '../types/auth.types';
+import { User, UserResponse } from '../types/user.types';
+
+export const authApi = {
+  login: async (credentials: LoginRequest): Promise<LoginResponse> => {
+    const res = await fetchFromClient('/auth/login', {
+      method: 'POST',
+      credentials: 'include',
+      body: JSON.stringify(credentials),
+    });
+    return res.json();
+  },
+
+  getMe: async (): Promise<User> => {
+    const res = await fetchFromClient('/users/me', {
+      method: 'GET',
+      credentials: 'include',
+    });
+    return res.json();
+  },
+
+  signUp: async (credentials: SignUpRequest) => {
+    const res = await fetchFromClient('/users', {
+      method: 'POST',
+      credentials: 'include',
+      body: JSON.stringify(credentials),
+    });
+
+    return res.json();
+  },
+
+  logout: async () => {
+    const res = await fetchFromClient('/auth/logout', {
+      method: 'POST',
+      credentials: 'include',
+    });
+    return res.json();
+  },
+};

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,8 +1,7 @@
 import { create } from 'zustand';
-import { User } from '../types/user.types';
 import { AuthState } from '../types/auth.types';
 
-export const useUserStore = create<AuthState>((set, get) => ({
+export const useAuthStore = create<AuthState>((set, get) => ({
   user: null,
   isAuthenticated: false,
   isLoading: false,

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { User } from '../types/user.types';
+import { AuthState } from '../types/auth.types';
+
+export const useUserStore = create<AuthState>((set, get) => ({
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  setUser: (user) =>
+    set({
+      user,
+      isAuthenticated: !!user,
+      isLoading: false,
+    }),
+  setLoading: (isLoading) => set({ isLoading }),
+  logout: () =>
+    set({
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+    }),
+}));

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -5,6 +5,18 @@ export interface LoginRequest {
   password: string;
 }
 
+export interface LoginResponse {
+  message: string;
+  user?: User;
+  error?: string;
+}
+
+export interface SignUpRequest {
+  email: string;
+  password: string;
+  nickname: string;
+}
+
 export interface AuthResponse {
   accessToken: string;
   refreshToken: string;

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -10,3 +10,12 @@ export interface AuthResponse {
   refreshToken: string;
   user: User;
 }
+
+export interface AuthState {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  setUser: (user: User | null) => void;
+  setLoading: (loading: boolean) => void;
+  logout: () => void;
+}

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -6,3 +6,8 @@ export interface User {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface UserResponse {
+  user?: User | null;
+  error?: string;
+}

--- a/src/utils/checkEmailExistence.ts
+++ b/src/utils/checkEmailExistence.ts
@@ -1,0 +1,22 @@
+import { fetchFromClient } from '@/src/lib/fetch/fetchFromClient';
+
+export async function checkEmailExistence(email: string): Promise<boolean | null> {
+  const credentials = {
+    email: email,
+    password: '1',
+  };
+  try {
+    const res = await fetchFromClient('/auth/login', {
+      method: 'POST',
+      credentials: 'include',
+      body: JSON.stringify(credentials),
+    });
+
+    if (res.status === 400) return true;
+    if (res.status === 404) return false;
+  } catch (error) {
+    console.error('이메일 확인 중 네트워크 또는 기타 오류 발생:', error);
+    return null;
+  }
+  return null;
+}

--- a/src/utils/checkEmailExistence.ts
+++ b/src/utils/checkEmailExistence.ts
@@ -1,22 +1,20 @@
-import { fetchFromClient } from '@/src/lib/fetch/fetchFromClient';
+import { BASE_API_URL } from '../constants/api';
 
 export async function checkEmailExistence(email: string): Promise<boolean | null> {
   const credentials = {
     email: email,
     password: '1',
   };
-  try {
-    const res = await fetchFromClient('/auth/login', {
-      method: 'POST',
-      credentials: 'include',
-      body: JSON.stringify(credentials),
-    });
 
-    if (res.status === 400) return true;
-    if (res.status === 404) return false;
-  } catch (error) {
-    console.error('이메일 확인 중 네트워크 또는 기타 오류 발생:', error);
-    return null;
-  }
+  const res = await fetch(`${BASE_API_URL}/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(credentials),
+  });
+
+  if (res.status === 400) return true;
+  if (res.status === 404) return false;
   return null;
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- 로그인, 회원가입, getMe, 로그아웃 `authApi.ts` 추가
- 로그인, 회원가입, getMe, 로그아웃 `useAuth.ts` 쿼리 훅 추가
- `authStore.ts` 유저 상태관리 추가
- account 페이지 추가
- checkEmailExistence 유틸 함수 추가 (유저 존재 확인 용도)

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/663ed252-4311-4480-9a8f-45a6fc838f89)


## 🛠️ 테스트 방법

<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->
`/test/route/auth` 페이지에서 테스트 가능합니다.
1. `useAuth.ts`에 쿼리 훅으로 테스트 가능합니다.
2. 테스트 페이지에서 훅을 가져옵니다
```
  const loginMutation = useLogin();
  const logoutMutation = useLogout();
  const { signUpAndLogin } = useSignUp();
  const { data, isLoading, isError, refetch } = useUser();
```
3.  임시 데이터로 테스트 가능합니다
```
  const handleLogin = async () => {
    const result = await loginMutation.mutateAsync(loginFormData);
    console.log(result);
  };

  const handleSignUp = async () => {
    const result = await signUpAndLogin(signUpFormData);
    console.log(result);
    setSignUpResult(result);
  };

  const handleFetchUser = async () => {
    refetch();
  };

  const handleLogout = () => {
    logoutMutation.mutate();
  };
```

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->
#25 #26 #27 

## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->