### PR TITLE
[Feat] 예약 내역 무한스크롤 및 스켈레톤 / 후기 등록 시 로딩 스피너 추가

### DIFF
--- a/src/app/profile/reservations/components/ReservationsCard.tsx
+++ b/src/app/profile/reservations/components/ReservationsCard.tsx
@@ -14,6 +14,7 @@ export default function ReservationsCard({
   reservation,
   showCancel = false,
   showReview = false,
+  isLast = false,
 }: ReservationsCardProps) {
   const { mutate: cancelReservation, isPending } = useCancelReservation();
   const { openCreateReviewModal, closeModal } = useModal();
@@ -61,7 +62,9 @@ export default function ReservationsCard({
   };
 
   return (
-    <div className='flex flex-col gap-[18px] bg-white px-[20px] py-[24px] border-b border-gray-200 last:border-none lg:flex-row lg:justify-between lg:items-end'>
+    <div
+      className={`flex flex-col gap-[18px] bg-white px-[20px] py-[24px] ${isLast ? '' : 'border-b border-gray-200'} lg:flex-row lg:justify-between lg:items-end`}
+    >
       {/* 내용 */}
       <Toast />
       <ConfirmModal />
@@ -82,7 +85,6 @@ export default function ReservationsCard({
           </div>
         </div>
       </div>
-
       {/* 버튼은 항상 세로로 아래 정렬 (모바일/태블릿 공통) */}
       <div className='flex flex-col gap-[10px] lg:items-end'>
         {showCancel && (
@@ -115,4 +117,5 @@ export interface ReservationsCardProps {
   reservation: MyReservation;
   showCancel?: boolean;
   showReview?: boolean;
+  isLast?: boolean;
 }

--- a/src/app/profile/reservations/page.tsx
+++ b/src/app/profile/reservations/page.tsx
@@ -1,63 +1,106 @@
 'use client';
 
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import { useMyReservations } from '@/src/hooks/useMyReservations';
+import { useToastStore } from '@/src/store/toastStore';
+
 import { MY_RESERVATION_STATUS_MAP } from '@/src/constants/my-reservation-status';
 import { MyReservationStatus } from '@/src/types/profile-reservation.types';
 import { DropdownItemButton } from '@/src/types/dropdown.types';
 
+import Toast from '@/src/components/common/toast/Toast';
 import Dropdown from '@/src/components/common/dropdowns/Dropdown';
 import ReservationsCard from './components/ReservationsCard';
+import { useInfiniteReservations } from '@/src/hooks/useInfiniteReservations';
 
-export default function ReservationsTestPage() {
+const BOTTOM_SKELETON_COUNT = 3; // 하단 스켈레톤 개수
+
+export default function ReservationsPage() {
+  const { showToast } = useToastStore();
   const [selectedStatus, setSelectedStatus] = useState<MyReservationStatus>('all');
-  const { reservations, cursorId, totalCount, isLoading } = useMyReservations(selectedStatus);
+  const {
+    data: myReservationsResponse,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+  } = useInfiniteReservations(selectedStatus);
+  const myReservations = myReservationsResponse?.pages.flatMap((page) => page.reservations) ?? [];
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage()
+            .catch((err) => console.error(err))
+            .finally(() => {
+              // 호출이 끝나면 다시 observe
+              observer.observe(entry.target);
+            });
+        }
+      });
+    });
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    if (isError) {
+      showToast('error', '예약 목록 조회 중 에러가 발생했습니다. 다시 시도해주세요.');
+    }
+  }, [isError, showToast]);
 
   // 드롭다운 메뉴 아이템 데이터
   const reservationStatusItems: DropdownItemButton[] = [
-    {
-      label: '모든 예약',
-      onClick: () => {
-        setSelectedStatus('all');
-      },
-    },
-    {
-      label: '예약 완료',
-      onClick: () => {
-        setSelectedStatus('pending');
-      },
-    },
-    {
-      label: '예약 승인',
-      onClick: () => {
-        setSelectedStatus('confirmed');
-      },
-    },
-    {
-      label: '예약 취소',
-      onClick: () => {
-        setSelectedStatus('canceled');
-      },
-    },
-    {
-      label: '예약 거절',
-      onClick: () => {
-        setSelectedStatus('declined');
-      },
-    },
-    {
-      label: '체험 완료',
-      onClick: () => {
-        setSelectedStatus('completed');
-      },
-    },
+    { label: '모든 예약', onClick: () => setSelectedStatus('all') },
+    { label: '예약 완료', onClick: () => setSelectedStatus('pending') },
+    { label: '예약 승인', onClick: () => setSelectedStatus('confirmed') },
+    { label: '예약 취소', onClick: () => setSelectedStatus('canceled') },
+    { label: '예약 거절', onClick: () => setSelectedStatus('declined') },
+    { label: '체험 완료', onClick: () => setSelectedStatus('completed') },
   ];
 
+  // 초기 로딩 시 스켈레톤 UI
+  if (isLoading) {
+    return (
+      <main className='flex flex-col items-center pb-[88px]'>
+        <div className='w-full flex flex-col lg:max-w-[720px] lg:mx-auto mt-6'>
+          {Array.from({ length: 5 }).map((_, idx) => (
+            <div
+              key={idx}
+              className='flex flex-col gap-[18px] bg-white px-[20px] py-[24px] border-b border-gray-200 animate-pulse lg:flex-row lg:justify-between lg:items-end rounded-[12px]'
+            >
+              <div className='w-[86px] h-[86px] lg:w-[98px] lg:h-[98px] bg-gray-200 rounded-[10px]' />
+
+              <div className='flex flex-col justify-between gap-[10px] flex-1'>
+                <div className='w-[64px] h-[20px] bg-gray-200 rounded-full' />
+                <div className='flex flex-col gap-[8px] pl-[4px]'>
+                  <div className='w-[70%] h-[20px] bg-gray-200 rounded-[6px]' />
+                  <div className='w-[50%] h-[18px] bg-gray-200 rounded-[6px]' />
+                  <div className='w-[40%] h-[18px] bg-gray-200 rounded-[6px]' />
+                </div>
+              </div>
+
+              <div className='w-full lg:w-[128px]'>
+                <div className='h-[42px] bg-gray-200 rounded-[10px]' />
+              </div>
+            </div>
+          ))}
+        </div>
+      </main>
+    );
+  }
+
   return (
-    <main className='min-h-screen flex flex-col items-center pb-[88px]'>
-      {/* 사이드바 추가 및 에러사항 없을 시에, 배경색 white로 */}
+    <main className='flex flex-col items-center pb-[88px] lg:pb-0'>
+      <Toast />
       <div className='w-full flex flex-col lg:max-w-[720px] lg:mx-auto'>
         <div className='hidden lg:flex lg:justify-end'>
           <div className='w-[180px]'>
@@ -70,16 +113,42 @@ export default function ReservationsTestPage() {
           </div>
         </div>
 
-        {reservations && reservations.length ? (
-          <div className='flex flex-col mt-[24px]'>
-            {reservations.map((reservation) => (
+        {myReservations && myReservations.length > 0 ? (
+          <div className='flex flex-col'>
+            {myReservations.map((reservation, index) => (
               <ReservationsCard
                 key={reservation.id}
                 reservation={reservation}
                 showCancel={reservation.status === 'pending'}
                 showReview={reservation.status === 'completed' && !reservation.reviewSubmitted}
+                isLast={index === myReservations.length - 1}
               />
             ))}
+            {/* 추가 페이지 로딩 시 하단 스켈레톤 */}
+            {isFetchingNextPage &&
+              Array.from({ length: BOTTOM_SKELETON_COUNT }).map((_, idx) => (
+                <div
+                  key={`skeleton-bottom-${idx}`}
+                  className='flex flex-col gap-[18px] bg-white px-[20px] py-[24px] border-b border-gray-200 animate-pulse lg:flex-row lg:justify-between lg:items-end rounded-[12px]'
+                >
+                  <div className='w-[86px] h-[86px] lg:w-[98px] lg:h-[98px] bg-gray-200 rounded-[10px]' />
+
+                  <div className='flex flex-col justify-between gap-[10px] flex-1'>
+                    <div className='w-[64px] h-[20px] bg-gray-200 rounded-full' />
+                    <div className='flex flex-col gap-[8px] pl-[4px]'>
+                      <div className='w-[70%] h-[20px] bg-gray-200 rounded-[6px]' />
+                      <div className='w-[50%] h-[18px] bg-gray-200 rounded-[6px]' />
+                      <div className='w-[40%] h-[18px] bg-gray-200 rounded-[6px]' />
+                    </div>
+                  </div>
+
+                  <div className='w-full lg:w-[128px]'>
+                    <div className='h-[42px] bg-gray-200 rounded-[10px]' />
+                  </div>
+                </div>
+              ))}
+            {/* 마지막 요소 감지용 */}
+            <div ref={sentinelRef} className='h-[1px]' />
           </div>
         ) : (
           <div className='flex flex-col items-center justify-center h-full'>

--- a/src/components/common/modals/CreateReviewModal.tsx
+++ b/src/components/common/modals/CreateReviewModal.tsx
@@ -117,7 +117,6 @@ export default function CreateReviewModal({
           )}
         </div>
 
-        {/* Textarea 수정 이후 반영 예정 */}
         <Textarea
           placeholder='후기를 작성해주세요'
           className='focus:outline focus:outline-primary-300'
@@ -126,14 +125,21 @@ export default function CreateReviewModal({
           error={errors.content}
         />
 
-        <div className='flex flex-col gap-[8px] pt-[32px]'>
-          <BaseButton type='submit' className='h-[48px] text-md' disabled={!isValid}>
-            작성하기
-          </BaseButton>
-          <BaseButton variant='outline' onClick={closeModal} className='h-[48px] text-md'>
-            취소하기
-          </BaseButton>
-        </div>
+        {isPending ? (
+          <div className='flex flex-col items-center py-[24px] space-y-[8px]'>
+            <div className='w-6 h-6 border-4 border-t-transparent border-primary-200 rounded-full animate-spin' />
+            <p className='text-sm text-gray-500 animate-pulse'>후기 등록 중입니다...</p>
+          </div>
+        ) : (
+          <div className='flex flex-col gap-[8px] pt-[32px]'>
+            <BaseButton type='submit' className='h-[48px] text-md' disabled={!isValid}>
+              작성하기
+            </BaseButton>
+            <BaseButton variant='outline' onClick={closeModal} className='h-[48px] text-md'>
+              취소하기
+            </BaseButton>
+          </div>
+        )}
       </form>
     </div>
   );

--- a/src/hooks/useInfiniteReservations.ts
+++ b/src/hooks/useInfiniteReservations.ts
@@ -1,0 +1,38 @@
+import { useInfiniteQuery, UseInfiniteQueryOptions } from '@tanstack/react-query';
+
+import { fetchFromClient } from '../lib/fetch/fetchFromClient';
+import { MyReservation, MyReservationStatus } from '../types/profile-reservation.types';
+
+const PAGE_SIZE = 10;
+
+interface MyReservationsResponse {
+  cursorId: number;
+  reservations: MyReservation[];
+  totalCount: number;
+}
+
+// 예약 목록을 무한 스크롤 방식으로 가져오는 훅
+export const useInfiniteReservations = (
+  status: MyReservationStatus,
+  options?: UseInfiniteQueryOptions<MyReservationsResponse, Error>
+) => {
+  return useInfiniteQuery<MyReservationsResponse>({
+    queryKey: ['my-reservations', status],
+
+    queryFn: async ({ pageParam = 0 }) => {
+      const query = new URLSearchParams();
+
+      query.set('size', PAGE_SIZE.toString());
+      status !== 'all' && query.set('status', status);
+      pageParam && query.set('cursorId', pageParam.toString());
+      // 무한스크롤이 반영될 페이지는 예액 내역 페이지 (reservations)
+      // 서버 api 경로는 my-reservations로 클라이언트 api 경로명과 일치하지 않음
+      // 구현 상의 문제는 없으나, 추후 클라이언트 api 경로명을 전면수정할 필요가 있어보임
+      const res = await fetchFromClient(`/my-reservations?${query.toString()}`);
+      if (!res.ok) throw new Error('예약 목록 조회 실패');
+      return res.json();
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.cursorId,
+  });
+};


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
- 예약 내역 카드 무한 스크롤
- 예약 내역 카드 스켈레톤 UI
- 후기 등록 시, 로딩 스피너 추가
- 마지막 카드 bnb에 묻히는 현상 해결 및 마지막 카드엔 회색 줄 없는 처리

## 📸 스크린샷

https://github.com/user-attachments/assets/49a56bc9-af61-49c0-afce-05345fdcdf89


예약 내역 페이지 무한 스크롤 및 스켈레톤

## 🛠️ 테스트 방법
1. /profile/reservations 페이지에서 확인 가능

## 🚧 관련 이슈
MEOW - 

## 💡 추가 정보
- 모바일 상단에 일부 여백은 Layout 컴포넌트 수정하면 정상적으로 보일 것 같습니다.
- 예약 내역 페이지는 GNB 담당하시는 분께서 상단에 다음과 같은 아이콘 추가와 바텀시트 적용 처리만 해주시면 페이지 작업은 끝이 납니다!
![image](https://github.com/user-attachments/assets/48b1b0e2-b6e4-450f-8c83-e0eac14ea032)
