### PR TITLE
[Feat] 통계 페이지 카드 여백 추가 및 반응형 구현

### DIFF
--- a/src/app/profile/analytics/monthly-pending-chart/MonthlyPendingChart.tsx
+++ b/src/app/profile/analytics/monthly-pending-chart/MonthlyPendingChart.tsx
@@ -25,38 +25,34 @@ export default function MonthlyPendingChart({ data }: MonthlyPendingChartProps) 
   }, []);
 
   return (
-    <section className='mt-[48px]'>
-      <h1 className='text-2xl font-bold text-black mb-[24px]'>이번 달 체험별 예약 신청 현황</h1>
-
+    <div className='w-full h-[300px]'>
       {data.length === 0 ? (
         <p className='text-sm text-gray-400'>예약 신청이 있는 체험이 아직 없어요.</p>
       ) : (
-        <div className='w-full h-[300px]'>
-          <ResponsiveContainer width='100%' height='100%'>
-            <BarChart data={data}>
-              <XAxis
-                dataKey='title'
-                tickFormatter={(value: string) =>
-                  value.length > labelLength ? `${value.slice(0, labelLength)}...` : value
-                }
-                tick={{
-                  fontSize: 12,
-                  dy: 10, // 막대 하단으로 내리기
-                  textAnchor: 'middle',
-                }}
-                tickLine={false}
-                interval={0}
-              />
-              <YAxis allowDecimals={false} />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey='pending' stackId='a' fill='#27A00E' name='예약 대기' />
-              <Bar dataKey='confirmed' stackId='a' fill='#0051FF' name='예약 승인' />
-              <Bar dataKey='completed' stackId='a' fill='#8407C7' name='체험 완료' />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
+        <ResponsiveContainer width='100%' height='100%'>
+          <BarChart data={data}>
+            <XAxis
+              dataKey='title'
+              tickFormatter={(value: string) =>
+                value.length > labelLength ? `${value.slice(0, labelLength)}...` : value
+              }
+              tick={{
+                fontSize: 12,
+                dy: 10, // 막대 하단으로 내리기
+                textAnchor: 'middle',
+              }}
+              tickLine={false}
+              interval={0}
+            />
+            <YAxis allowDecimals={false} />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey='pending' stackId='a' fill='#27A00E' name='예약 대기' />
+            <Bar dataKey='confirmed' stackId='a' fill='#0051FF' name='예약 승인' />
+            <Bar dataKey='completed' stackId='a' fill='#8407C7' name='체험 완료' />
+          </BarChart>
+        </ResponsiveContainer>
       )}
-    </section>
+    </div>
   );
 }

--- a/src/app/profile/analytics/page.tsx
+++ b/src/app/profile/analytics/page.tsx
@@ -1,17 +1,21 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
+import { useGnb } from '@/src/hooks/useGnb';
 import { useAllMyActivitiesReservationByMonth } from '@/src/hooks/useAllMyActivitiesReservationByMonth';
-import SummaryCards from './components/SummaryCards';
-import ReservationLineChart from './components/ReservationLineChart';
-import MyActivitiesReviewList from './review-summary/MyActivitiesReviewList';
-import MonthlyPendingChart from './monthly-pending-chart/MonthlyPendingChart';
 import { useMonthlyPendingChartData } from '@/src/hooks/useMonthlyPendingChartData';
 
+import SummaryCards from './reservation-stats/SummaryCards';
+import ReservationLineChart from './reservation-stats/ReservationLineChart';
+import MyActivitiesReviewList from './review-summary/MyActivitiesReviewList';
+import MonthlyPendingChart from './monthly-pending-chart/MonthlyPendingChart';
+
 export default function AnalyticsPage() {
+  const router = useRouter();
   const [selectedDate, setSelectedDate] = useState(new Date());
-  const [today] = useState(() => new Date());
+  const today = useMemo(() => new Date(), []);
 
   const {
     data: analyticsData,
@@ -21,9 +25,14 @@ export default function AnalyticsPage() {
 
   const { chartData, isLoading: isPendingChartLoading } = useMonthlyPendingChartData(today);
 
+  useGnb({
+    title: '내 체험 통계',
+    backAction: () => router.back(),
+  });
+
   if (isError) {
     return (
-      <main className='flex items-center justify-center text-red-500 text-lg'>
+      <main className='flex items-center justify-center text-red-500 dark:text-red-300 text-lg'>
         통계 데이터를 불러오는 중 오류가 발생했어요.
       </main>
     );
@@ -31,10 +40,14 @@ export default function AnalyticsPage() {
 
   return (
     <main className='w-full max-w-[960px] mx-auto px-[20px] pb-[88px]'>
-      <h1 className='text-2xl font-bold text-black mb-[24px]'>전체 체험 예약 통계</h1>
+      <h1 className='text-2xl font-bold text-black dark:text-gray-200 mb-[24px]'>
+        전체 체험 예약 통계
+      </h1>
 
       {isLoading ? (
-        <p className='text-gray-500'>로딩 중...</p>
+        <p className='text-gray-500 dark:text-gray-300'>
+          잠시만 기다려 주세요, 예약 현황을 준비 중입니다
+        </p>
       ) : (
         <>
           <SummaryCards data={analyticsData ?? []} />
@@ -43,11 +56,24 @@ export default function AnalyticsPage() {
       )}
 
       {/* 이번 달 체험별 예약 신청 현황 차트 */}
-      {!isPendingChartLoading && <MonthlyPendingChart data={chartData} />}
+      <section className='mt-[48px]'>
+        <h1 className='text-2xl font-bold text-black dark:text-gray-200 mb-[24px]'>
+          이번 달 체험별 예약 신청 현황
+        </h1>
+        {isPendingChartLoading ? (
+          <p className='text-gray-500 dark:text-gray-300'>
+            잠시만 기다려 주세요, 체험별 신청 데이터를 불러오고 있어요.
+          </p>
+        ) : (
+          <MonthlyPendingChart data={chartData} />
+        )}
+      </section>
 
       {/* 체험별 리뷰 요약 */}
       <section className='mt-[48px]'>
-        <h1 className='text-2xl font-bold text-black mb-[24px]'>체험별 리뷰 요약</h1>
+        <h1 className='text-2xl font-bold text-black dark:text-gray-200 mb-[24px]'>
+          체험별 리뷰 요약
+        </h1>
         <MyActivitiesReviewList today={today} />
       </section>
     </main>

--- a/src/app/profile/analytics/reservation-stats/ReservationLineChart.tsx
+++ b/src/app/profile/analytics/reservation-stats/ReservationLineChart.tsx
@@ -37,12 +37,12 @@ export default function ReservationLineChart({ data }: Props) {
   };
 
   return (
-    <Card className='rounded-2xl shadow-sm mt-[24px]'>
-      <CardHeader className='text-sm text-gray-500'>전체 예약 추이</CardHeader>
-      <CardContent className='h-[280px]'>
+    <Card className='rounded-2xl border border-gray-100 dark:border-gray-300 bg-white dark:bg-gray-800 p-[20px] shadow-sm mt-[24px] space-y-[12px]'>
+      <CardHeader className='text-sm text-gray-500 dark:text-gray-400'>전체 예약 추이</CardHeader>
+      <CardContent className='p-0 h-[280px]'>
         <ResponsiveContainer width='100%' height='100%'>
           <LineChart data={chartData}>
-            <XAxis dataKey='date' stroke='#B3A8A1' fontSize={12} />
+            <XAxis dataKey='date' stroke='#B3A8A1' fontSize={12} tickMargin={12} />
             <YAxis stroke='#B3A8A1' fontSize={12} />
             <Tooltip
               formatter={(value, name) => [value, labelMap[name as string] || name]}

--- a/src/app/profile/analytics/reservation-stats/SummaryCards.tsx
+++ b/src/app/profile/analytics/reservation-stats/SummaryCards.tsx
@@ -43,7 +43,10 @@ export default function SummaryCards({ data }: SummaryCardsProps) {
   return (
     <div className='grid grid-cols-2 gap-[12px] md:grid-cols-4 mt-[20px]'>
       {summaryItems.map((item) => (
-        <Card key={item.label} className='rounded-2xl shadow-sm'>
+        <Card
+          key={item.label}
+          className='rounded-2xl border border-gray-100 bg-white p-[20px] shadow-sm space-y-[12px]'
+        >
           <CardHeader className={`text-sm font-medium ${item.labelColor}`}>{item.label}</CardHeader>
           <CardContent>
             <div

--- a/src/app/profile/analytics/review-summary/MyActivitiesReviewList.tsx
+++ b/src/app/profile/analytics/review-summary/MyActivitiesReviewList.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useState } from 'react';
 import { useMyActivities } from '@/src/hooks/useMyActivities';
 import MyActivityReviewCard from './MyActivityReviewCard';
+import BaseButton from '@/src/components/common/buttons/BaseButton';
 
 interface MyActivitiesReviewListProps {
   today: Date;
@@ -9,18 +11,28 @@ interface MyActivitiesReviewListProps {
 
 export default function MyActivitiesReviewList({ today }: MyActivitiesReviewListProps) {
   const { myActivities, isLoading, isError } = useMyActivities(today);
+  const [visibleCount, setVisibleCount] = useState(10); // 처음 10개 보여주기
 
-  if (isLoading) return <p className='text-gray-500'>체험 목록 불러오는 중...</p>;
-  if (isError || !myActivities) return <p className='text-red-500'>불러오기 실패</p>;
+  if (isLoading)
+    return (
+      <p className='text-gray-500 dark:text-gray-400'>
+        잠시만 기다려 주세요, 리뷰 데이터를 불러오고 있어요.
+      </p>
+    );
+  if (isError || !myActivities) return <p className='text-red-300'>불러오기 실패</p>;
 
-  // 평점 높은 순 → 리뷰 수 많은 순 정렬
   const sorted = [...myActivities].sort(
     (a, b) => b.rating - a.rating || b.reviewCount - a.reviewCount
   );
 
+  // 평점 높은 순 → 리뷰 수 많은 순 정렬
+  const handleLoadMore = () => {
+    setVisibleCount((prev) => prev + 10);
+  };
+
   return (
     <div className='space-y-6'>
-      {sorted.map((activity) => (
+      {sorted.slice(0, visibleCount).map((activity) => (
         <MyActivityReviewCard
           key={activity.id}
           activityId={activity.id}
@@ -29,6 +41,18 @@ export default function MyActivitiesReviewList({ today }: MyActivitiesReviewList
           reviewCount={activity.reviewCount}
         />
       ))}
+
+      {visibleCount < sorted.length && (
+        <div className='mt-[16px] flex justify-center'>
+          <BaseButton
+            variant='outline'
+            className='w-auto px-[28px] text-md hover:bg-gray-100 dark:hover:bg-gray-700'
+            onClick={handleLoadMore}
+          >
+            더보기
+          </BaseButton>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/profile/analytics/review-summary/MyActivityReviewCard.tsx
+++ b/src/app/profile/analytics/review-summary/MyActivityReviewCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import StarFillIcon from '@/src/components/common/icons/StarFillIcon';
 import { useReviews } from '@/src/hooks/activities/useReviews';
 
 interface MyActivityReviewCardProps {
@@ -24,24 +25,23 @@ export default function MyActivityReviewCard({
   const reviews: Review[] = data?.reviews?.slice(0, 2) ?? [];
 
   return (
-    <div className='rounded-[12px] border border-gray-100 bg-white p-[20px] shadow-sm space-y-[12px]'>
-      <div>
-        <h2 className='text-lg font-bold text-black mb-[4px]'>{title}</h2>
-        <p className='text-sm text-gray-600'>
-          ⭐ {rating.toFixed(1)} / 리뷰 {reviewCount}개
-        </p>
+    <div className='rounded-[12px] border border-gray-100 dark:border-gray-300 bg-white dark:bg-gray-800 p-[20px] shadow-sm space-y-[12px]'>
+      <h2 className='text-lg font-bold text-black dark:text-gray-100 mb-[4px]'>{title}</h2>
+      <div className='flex items-center gap-[4px] text-sm text-gray-600 dark:text-gray-400'>
+        <StarFillIcon className='w-[16px] h-[16px] text-yellow-200' />
+        <span>
+          {rating.toFixed(1)} / 리뷰 {reviewCount}개
+        </span>
       </div>
-
-      <div className='h-[1px] bg-gray-200' />
-
+      <div className='h-[1px] bg-gray-200 dark:bg-gray-400' />
       {isLoading ? (
-        <p className='text-sm text-gray-400'>리뷰 불러오는 중...</p>
+        <p className='text-sm text-gray-400 dark:text-gray-400'>리뷰 불러오는 중...</p>
       ) : reviews.length === 0 ? (
-        <p className='text-sm text-gray-400'>리뷰가 아직 없어요.</p>
+        <p className='text-sm text-gray-400 dark:text-gray-400'>리뷰가 아직 없어요.</p>
       ) : (
         <ul className='space-y-[4px]'>
           {reviews.map((review) => (
-            <li key={review.id} className='text-sm text-gray-800'>
+            <li key={review.id} className='text-sm text-gray-800 dark:text-gray-200'>
               “{review.content}”
             </li>
           ))}

--- a/src/app/profile/analytics/review-summary/SkeletonReviewCard.tsx
+++ b/src/app/profile/analytics/review-summary/SkeletonReviewCard.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+export default function SkeletonReviewCard() {
+  return (
+    <div className='shimmer rounded-[12px] border border-gray-100 dark:border-gray-300 bg-white dark:bg-gray-800 p-[20px] shadow-sm space-y-[12px]'>
+      <div className='h-[20px] w-[50%] bg-gray-200 dark:bg-gray-300 rounded' />
+
+      <div className='h-[16px] w-[30%] bg-gray-200 dark:bg-gray-300 rounded' />
+
+      <div className='h-[1px] bg-gray-200 dark:bg-gray-300 ' />
+
+      <div className='space-y-[6px]'>
+        <div className='h-[14px] w-full bg-gray-200 dark:bg-gray-300 rounded' />
+        <div className='h-[14px] w-[80%] bg-gray-200 dark:bg-gray-300 rounded' />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
- GNB 추가 등 반응형 구현
- 통계 페이지 리팩토링
  - 동일 로직 활용
- 통계 페이지 카드 여백 추가
- 로딩 멘트 통일
- 더보기 버튼 클릭 시 추가 리뷰 카드가 나오게 설정
- 스켈레톤 UI 추가

## 📸 스크린샷

https://github.com/user-attachments/assets/8af7f76c-917d-4d49-b724-286f56cc9ce8

PC 버전의 통계 페이지


https://github.com/user-attachments/assets/7e0fb6ba-bbe9-4d2a-9630-df830f58a1f3

통계 페이지 모바일

## 🛠️ 테스트 방법
1. 

## 🚧 관련 이슈
MEOW - 201

## 💡 추가 정보
- 추후에 다크모드 반영 및 일부 UI 수정 필요