### PR TITLE
[Fix] 예약 현황 캘린더 fine-tune(캘린더 tile 너비 줄여듦 현상 & 캘린더 쿼리 무효화)

### DIFF
--- a/src/app/profile/my-reservations/components/MyReservationsModalCard.tsx
+++ b/src/app/profile/my-reservations/components/MyReservationsModalCard.tsx
@@ -5,7 +5,10 @@ const LABEL_STYLE_MAP = {
     bg: 'bg-green-100 dark:bg-dark-green-200',
     text: 'text-green-200 dark:text-dark-green-100',
   },
-  '예약 취소': { bg: 'bg-gray-100 dark:bg-gray-700', text: 'text-gray-600 dark:text-gray-400' },
+  '예약 취소': {
+    bg: 'bg-gray-100 dark:bg-gray-700',
+    text: 'text-gray-600 dark:text-gray-400',
+  },
   '예약 거절': {
     bg: 'bg-red-100 dark:bg-dark-red-200',
     text: 'text-red-300 dark:text-dark-red-100',

--- a/src/app/profile/my-reservations/components/ReservationCalendar.tsx
+++ b/src/app/profile/my-reservations/components/ReservationCalendar.tsx
@@ -15,7 +15,6 @@ import { MyActivity } from '@/src/types/my-activity-reservation.types';
 import { DropdownItemButton } from '@/src/types/dropdown.types';
 
 import Dropdown from '@/src/components/common/dropdowns/Dropdown';
-import ArrowButton from '@/src/components/common/buttons/ArrowButton';
 
 import '@/src/styles/reservation-calendar.css';
 
@@ -124,20 +123,24 @@ export default function ReservationCalendar() {
 
   return (
     <div className='mx-auto min-w-[327px] w-full react-calendar-wrapper'>
-      <div className='mb-[64px]'>
-        {dropdownItems.length > 0 ? (
+      {isLoading ? (
+        <div className='w-full h-[72px] flex justify-center items-center mb-[64px]'>
+          <div className='w-6 h-6 border-4 border-t-transparent border-primary-200 rounded-full animate-spin' />
+        </div>
+      ) : dropdownItems.length > 0 ? (
+        <div className='mb-[64px]'>
           <Dropdown
             dropdownItems={dropdownItems}
             selectedValue={selectedMyActivity ? selectedMyActivity.title : '체험을 선택해주세요'}
             bottomSheetTitle='체험명'
             triggerLabel='체험명'
           />
-        ) : (
-          <div className='text-center text-gray-600 text-md'>
-            등록된 체험이 없습니다. 체험 등록 후 이용해주세요.
-          </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className='mb-[64px] text-center text-gray-600 text-md'>
+          등록된 체험이 없습니다. 체험 등록 후 이용해주세요.
+        </div>
+      )}
       <Calendar
         className='reservation-calendar-wrapper'
         locale='ko-KR'

--- a/src/hooks/useUpdateReservation.ts
+++ b/src/hooks/useUpdateReservation.ts
@@ -19,8 +19,18 @@ export function useUpdateReservation(activityId: number, scheduleId?: number) {
       });
     },
     onSuccess: () => {
+      // 시간 리스트 쿼리 무효화(invalidate) -> 최신 데이터 fetch
       queryClient.invalidateQueries({
         queryKey: ['reservationsByTime', scheduleId],
+      });
+
+      // 캘린더 쿼리 무효화(invalidate) -> 최신 데이터 fetch
+      const now = new Date();
+      const year = now.getFullYear();
+      const month = `0${now.getMonth() + 1}`.slice(-2);
+
+      queryClient.invalidateQueries({
+        queryKey: ['myActivityReservationByMonth', activityId, year, month],
       });
     },
   });

--- a/src/styles/reservation-calendar.css
+++ b/src/styles/reservation-calendar.css
@@ -97,8 +97,6 @@
 
 .react-calendar-wrapper .react-calendar__tile--active {
   background-color: transparent !important;
-  display: flex;
-  align-items: center;
   color: #6e625a;
 }
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
- 예약 현황 페이지
  - 드롭다운 부분 로딩 스피너 추가
  - "등록된 체험이 없습니다. 체험 등록 후 이용해주세요." 문구 여백 조정으로 캘린더 깜빡임 현상 완화
  - 캘린더 날짜 클릭 시, tile 내의 label 줄어듦 현상 해결
  - 예약 상태 변경 시, 캘린더에도 반영되도록 로직 추가


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/47533490-b152-4c70-a077-12babf2321e1)
날짜 클릭 시에도 유지되는 label의 너비

## 🛠️ 테스트 방법
1.  `/profile/my-reservations 페이지`에서 확인 가능

## 🚧 관련 이슈

## 💡 추가 정보
- 시간이 좀 걸리긴 하나, 예약 상태 변경 시에 모달 내에선 바로 반영되도록 기존 로직이 되어있었고, 이 부분은 확인하고 PR을 과거에 올렸었습니다
- 캘린더 부분에는 바로 반영될 수 있도록 하는 로직이 없어서, 해당 로직만 추가해서 PR 올린 상태입니다.