### PR TITLE
[Fix] Fine Tune - 리다이랙트 에러, 유효하지 않은 시간 입력

### DIFF
--- a/src/app/profile/my-activities/components/RegisterExperienceForm.tsx
+++ b/src/app/profile/my-activities/components/RegisterExperienceForm.tsx
@@ -141,7 +141,7 @@ export default function RegisterExperienceForm({
               className='text-md font-semibold'
               disabled={!isDirty || !isValid || isSubmitting}
             >
-              {isSubmitting ? '처리 중...' : mode === 'edit' ? '수정하기' : '등록 하기'}
+              {isSubmitting ? '처리 중...' : mode === 'edit' ? '수정하기' : '등록하기'}
             </BaseButton>
           </div>
         )}

--- a/src/app/profile/my-activities/components/register-calendar/DateTimePicker.tsx
+++ b/src/app/profile/my-activities/components/register-calendar/DateTimePicker.tsx
@@ -4,6 +4,7 @@ interface CustomDatePickerProps {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   placeholder?: string;
+  min?: string;
 }
 
 interface CustomTimePickerProps {
@@ -30,6 +31,7 @@ export function CustomDatePicker({
   value,
   onChange,
   placeholder = '연도. 월. 일',
+  min,
 }: CustomDatePickerProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -43,6 +45,7 @@ export function CustomDatePicker({
         type='date'
         value={value}
         onChange={onChange}
+        min={min}
         className='absolute left-0 top-0 w-full h-full opacity-0 cursor-pointer'
       />
     </div>

--- a/src/app/profile/my-activities/components/register-calendar/DateTimePicker.tsx
+++ b/src/app/profile/my-activities/components/register-calendar/DateTimePicker.tsx
@@ -62,7 +62,7 @@ export function CustomTimePicker({
 
   return (
     <div className='relative select-none' onClick={() => inputRef.current?.showPicker()}>
-      <span className='text-md font-regular text-gray-800 pointer-events-none'>
+      <span className='text-md font-regular text-gray-800 pointer-events-none whitespace-nowrap'>
         {formatTime(value)}
       </span>
       <input

--- a/src/app/profile/my-activities/components/register-calendar/RegisterCalendarItem.tsx
+++ b/src/app/profile/my-activities/components/register-calendar/RegisterCalendarItem.tsx
@@ -1,6 +1,11 @@
 import Image from 'next/image';
 import { CustomDatePicker, CustomTimePicker } from './DateTimePicker';
-import { getTodayDateStr } from '@/src/utils/my-activities-schedule';
+import {
+  getTodayDateStr,
+  getMinEndTimeStr,
+  getMinStartTime,
+  normalizeEndTime,
+} from '@/src/utils/my-activities-time';
 
 interface RegisterCalendarItemProps {
   id: string;
@@ -39,14 +44,17 @@ export default function RegisterCalendarItem({
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             onChange(id, 'startTime', e.target.value)
           }
+          min={getMinStartTime(date)}
         />
         <span className='text-md font-regular text-gray-400'>~</span>
         <CustomTimePicker
           value={endTime}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            onChange(id, 'endTime', e.target.value)
-          }
-          min={startTime || undefined}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            const rawEndTime = e.target.value;
+            const normalized = normalizeEndTime(startTime, rawEndTime);
+            onChange(id, 'endTime', normalized);
+          }}
+          min={getMinEndTimeStr(startTime)}
         />
       </div>
       <div className='flex justify-end'>

--- a/src/app/profile/my-activities/components/register-calendar/RegisterCalendarItem.tsx
+++ b/src/app/profile/my-activities/components/register-calendar/RegisterCalendarItem.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { CustomDatePicker, CustomTimePicker } from './DateTimePicker';
+import { getTodayDateStr } from '@/src/utils/my-activities-schedule';
 
 interface RegisterCalendarItemProps {
   id: string;
@@ -26,6 +27,7 @@ export default function RegisterCalendarItem({
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             onChange(id, 'date', e.target.value)
           }
+          min={getTodayDateStr()}
         />
       </div>
       <div className='flex justify-center'>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,14 +2,19 @@
 import { useRouter } from 'next/navigation';
 import { useBreakpoint } from '@/src/hooks/useBreakpoint';
 import Sidebar from './components/Sidebar';
+import { useEffect } from 'react';
 
 export default function Profile() {
   const { isDesktop, hasMounted } = useBreakpoint();
   const router = useRouter();
-  //  임시로 만든 방법 : 로딩 중 sidebar가 두 번 뜸
-  if (hasMounted && isDesktop) {
-    router.replace('/profile/my-info');
-    return null;
-  } else if (!isDesktop) return <Sidebar />;
+
+  useEffect(() => {
+    if (hasMounted && isDesktop) {
+      router.replace('/profile/my-info');
+    }
+  }, [hasMounted, isDesktop]);
+
+  if (!hasMounted) return null;
+  if (!isDesktop) return <Sidebar />;
   else return null;
 }

--- a/src/utils/my-activities-schedule.ts
+++ b/src/utils/my-activities-schedule.ts
@@ -21,11 +21,6 @@ export function convertSchedulesToCalendarItems(
   }));
 }
 
-export function getTodayDateStr() {
-  const today = new Date();
-  return today.toISOString().split('T')[0]; // 'YYYY-MM-DD'
-}
-
 // 날짜/시간 비교 유틸
 export function compareDateTime(a: CalendarItem, b: CalendarItem) {
   // "2024-06-14" + "T" + "14:00" 식으로 합쳐서 Date 비교

--- a/src/utils/my-activities-schedule.ts
+++ b/src/utils/my-activities-schedule.ts
@@ -21,6 +21,11 @@ export function convertSchedulesToCalendarItems(
   }));
 }
 
+export function getTodayDateStr() {
+  const today = new Date();
+  return today.toISOString().split('T')[0]; // 'YYYY-MM-DD'
+}
+
 // 날짜/시간 비교 유틸
 export function compareDateTime(a: CalendarItem, b: CalendarItem) {
   // "2024-06-14" + "T" + "14:00" 식으로 합쳐서 Date 비교

--- a/src/utils/my-activities-time.ts
+++ b/src/utils/my-activities-time.ts
@@ -25,7 +25,7 @@ export const getMinEndTimeStr = (startTime?: string): string | undefined => {
 };
 
 export const normalizeEndTime = (startTime: string, endTime: string): string => {
-  if (!/\d{2}:\d{2}/.test(startTime) || !/\d{2}:\d{2}/.test(endTime)) return endTime;
+  if (!/^\d{2}:\d{2}$/.test(startTime) || !/^\d{2}:\d{2}$/.test(endTime)) return endTime;
 
   const [startH, startM] = startTime.split(':').map(Number);
   const [endH, endM] = endTime.split(':').map(Number);
@@ -34,7 +34,7 @@ export const normalizeEndTime = (startTime: string, endTime: string): string => 
   const endMin = endH * 60 + endM;
 
   if (endMin <= startMin) {
-    const adjusted = endMin + 720;
+    const adjusted = endMin + 12 * 60; // 12 hours in minutes
     const normH = String(Math.floor(adjusted / 60) % 24).padStart(2, '0');
     const normM = String(adjusted % 60).padStart(2, '0');
     return `${normH}:${normM}`;

--- a/src/utils/my-activities-time.ts
+++ b/src/utils/my-activities-time.ts
@@ -1,0 +1,44 @@
+export const getTodayDateStr = (): string => {
+  const today = new Date();
+  const offset = today.getTimezoneOffset() * 60000; // ms 단위
+  const localDate = new Date(today.getTime() - offset);
+  return localDate.toISOString().split('T')[0]; // YYYY-MM-DD
+};
+
+export const getMinStartTime = (dateStr: string): string => {
+  const todayStr = getTodayDateStr();
+  // 오늘이면 현재 시각 기준 HH:mm 반환
+  if (dateStr === todayStr) {
+    const now = new Date();
+    const hours = now.getHours().toString().padStart(2, '0');
+    const minutes = now.getMinutes().toString().padStart(2, '0');
+    return `${hours}:${minutes}`;
+  }
+  // 내일 이후면 00:00부터 가능
+  return '00:00';
+};
+
+export const getMinEndTimeStr = (startTime?: string): string | undefined => {
+  if (!startTime || !/^\d{2}:\d{2}$/.test(startTime)) return undefined;
+
+  return startTime;
+};
+
+export const normalizeEndTime = (startTime: string, endTime: string): string => {
+  if (!/\d{2}:\d{2}/.test(startTime) || !/\d{2}:\d{2}/.test(endTime)) return endTime;
+
+  const [startH, startM] = startTime.split(':').map(Number);
+  const [endH, endM] = endTime.split(':').map(Number);
+
+  const startMin = startH * 60 + startM;
+  const endMin = endH * 60 + endM;
+
+  if (endMin <= startMin) {
+    const adjusted = endMin + 720;
+    const normH = String(Math.floor(adjusted / 60) % 24).padStart(2, '0');
+    const normM = String(adjusted % 60).padStart(2, '0');
+    return `${normH}:${normM}`;
+  }
+
+  return endTime;
+};


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

<!-- 이 PR에서 무엇이 변경되었는지 간략하게 설명해주세요 -->
- [x] 리다이랙트 처리 : 나중에 확인 할 필요 있을거 같습니다.  
- [x] '등록하기'
- [x] 오늘 이후 날짜 선택 못하도록 만들기
- [x] 시작 시간 보다 이른 시간을 선택할 때 (같은 시간 선택 시) 오후로 변경
- [x] 또 다른 예외 사항이 있을 것 같아서 (같은 시간 대 겹쳐서 두기 ) 토스트는 유지 시켰습니다. 
 

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/d8cdcf72-f105-4351-b815-b38dbaeda27d



## 🛠️ 테스트 방법

<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

1.
2.
3.

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->