### PR TITLE
[Fix] 상세 페이지 디테일 수정

### DIFF
--- a/src/app/activities/[id]/components/ExperienceResponsiveLayout.tsx
+++ b/src/app/activities/[id]/components/ExperienceResponsiveLayout.tsx
@@ -58,7 +58,6 @@ export default function ExperienceResponsiveLayout({
   const { isDesktop } = useBreakpoint();
   const { theme } = useThemeStore();
 
-  // Move all hook calls before any conditional logic
   const isOwner = user?.id === activity.userId;
 
   const handleDeleteActivity = useCallback(async () => {
@@ -105,7 +104,7 @@ export default function ExperienceResponsiveLayout({
 
   useGnb({
     title: activity.title,
-    backAction: () => router.push('/profile'),
+    backAction: () => router.push('/'),
     rightButtons,
   });
 
@@ -148,6 +147,8 @@ export default function ExperienceResponsiveLayout({
               <ExperienceImageViewer
                 bannerImageUrl={activity.bannerImageUrl}
                 subImages={activity.subImages}
+                pageTitle={activity.title}
+                backAction={() => router.push('/')}
               />
             </div>
             <div className='flex-1 relative'>
@@ -169,6 +170,7 @@ export default function ExperienceResponsiveLayout({
                     dropdownItems={dropdownItems}
                     bottomSheetTitle='게시물 관리'
                     trigger={<KebabIcon size={24} className='text-gray-600 dark:text-gray-400' />}
+                    isMobile={true}
                   />
                 )}
               </div>
@@ -218,6 +220,8 @@ export default function ExperienceResponsiveLayout({
           <ExperienceImageViewer
             bannerImageUrl={activity.bannerImageUrl}
             subImages={activity.subImages}
+            pageTitle={activity.title}
+            backAction={() => router.push('/')}
           />
 
           <div className='flex flex-col gap-[24px]'>
@@ -240,20 +244,6 @@ export default function ExperienceResponsiveLayout({
                   onToggle={() => toggleFavorite(activity)}
                   className='w-[22px] h-[22px] cursor-pointer text-gray-600 dark:text-gray-400'
                 />
-              )}
-              {isOwner && (
-                <div className='flex items-center justify-center w-[22px] h-[22px]'>
-                  <ActivityDropdown
-                    dropdownItems={dropdownItems}
-                    bottomSheetTitle='게시물 관리'
-                    trigger={
-                      <KebabIcon
-                        size={22}
-                        className='text-gray-600 dark:text-gray-400 align-middle'
-                      />
-                    }
-                  />
-                </div>
               )}
             </div>
           </div>

--- a/src/app/activities/[id]/components/common/ActivityDropdown.tsx
+++ b/src/app/activities/[id]/components/common/ActivityDropdown.tsx
@@ -10,11 +10,18 @@ interface Props {
   dropdownItems: DropdownItemButton[];
   bottomSheetTitle: string;
   trigger: React.ReactNode;
+  isMobile?: boolean;
 }
 
-export default function ActivityDropdown({ dropdownItems, bottomSheetTitle, trigger }: Props) {
+export default function ActivityDropdown({
+  dropdownItems,
+  bottomSheetTitle,
+  trigger,
+  isMobile: isMobileProp,
+}: Props) {
   const [isOpen, setIsOpen] = useState(false);
-  const { isMobile } = useBreakpoint();
+  const { isMobile: isMobileBreakpoint } = useBreakpoint();
+  const isMobile = isMobileProp !== undefined ? isMobileProp : isMobileBreakpoint;
 
   useEffect(() => {
     const close = () => setIsOpen(false);

--- a/src/app/activities/[id]/components/experience/ExperienceImageViewer.tsx
+++ b/src/app/activities/[id]/components/experience/ExperienceImageViewer.tsx
@@ -15,12 +15,14 @@ interface ExperienceImageViewerProps {
   bannerImageUrl: string;
   subImages: SubImage[];
   pageTitle?: string;
+  backAction?: (() => void) | null;
 }
 
 export default function ExperienceImageViewer({
   bannerImageUrl,
   subImages,
   pageTitle = '체험 상세',
+  backAction = null,
 }: ExperienceImageViewerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -44,7 +46,7 @@ export default function ExperienceImageViewer({
   const closeImageViewer = () => {
     setIsOpen(false);
     setTitle(pageTitle);
-    setBackAction(null);
+    setBackAction(backAction);
   };
 
   useEffect(() => {

--- a/src/app/activities/[id]/components/reservation/ScheduleTimeItem.tsx
+++ b/src/app/activities/[id]/components/reservation/ScheduleTimeItem.tsx
@@ -77,7 +77,9 @@ export default function ScheduleTimeItem({
           {formattedStartTime} ~ {formattedEndTime}
         </p>
 
-        {isDisabled && <p className='text-xs text-red-400 mt-1'>이미 예약한 시간입니다</p>}
+        {isDisabled && (
+          <p className='text-xs text-red-300 mt-1 dark:dark-red-200'>이미 예약한 시간입니다</p>
+        )}
       </button>
     </div>
   );


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [ ] 스타일 변경 (UI/UX)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항

- 모바일 기준 뒤로가기 버튼 눌렀을 때 메인으로 이동할 수 있도록 변경
- 모바일 기준 상세 페이지 내에 케밥 메뉴 한 번 더 보이는 것 삭제
- 이미지 미리보기에서 뒤로 갔을 때 title props로 받아오도록 수정

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## 🛠️ 테스트 방법

<!-- 이 기능을 테스트하는 방법을 설명해주세요 -->

1.
2.
3.

## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보

케밥 메뉴 누를 때 데스크톱 드롭다운이 나오다가 모바일로 바뀝니다. 이 부분은 수정 아직 못 했습니다.
모바일 기준 메인페이지에서 상세페이지 접속할 때는 지도가 잘 뜨지만, 새로고침하면 지도가 안보입니다. 이 부분은 제 로컬에서는 잘 되고 있어서 뭐가 문제인지 찾지 못 해 수정 못 했습니다.