### PR TITLE
[Fix] 캘린더 오늘 날짜의 label width 줄어듦 현상 해결

### DIFF
--- a/src/app/profile/my-reservations/components/ReservationCalendar.tsx
+++ b/src/app/profile/my-reservations/components/ReservationCalendar.tsx
@@ -94,7 +94,7 @@ export default function ReservationCalendar() {
     if (contents.length === 0) return null;
 
     return (
-      <div className='flex flex-col bottom-[10px] left-0 right-0 px-1 text-center text-xs font-medium gap-[2px]'>
+      <div className='w-full flex flex-col bottom-[10px] left-0 right-0 px-1 text-center text-xs font-medium gap-[2px]'>
         {contents}
       </div>
     );

--- a/src/styles/reservation-calendar.css
+++ b/src/styles/reservation-calendar.css
@@ -96,11 +96,13 @@
 }
 
 .react-calendar-wrapper .react-calendar__tile--active {
+  width: 100%;
   background-color: transparent !important;
   color: #6e625a;
 }
 
 .react-calendar-wrapper .react-calendar__tile--now {
+  width: 100%;
   background: transparent;
   display: flex;
   align-items: center;


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 환경 설정 (Configuration)
- [ ] 기타 (Other)

## 🔍 변경 사항
- 예약 현황 페이지 캘린더 오늘 날짜의 label width 줄어듦 현상 해결

## 📸 스크린샷

https://github.com/user-attachments/assets/d20d1418-4c81-423f-bb9d-e65bd91c5504



## 🛠️ 테스트 방법


## 🚧 관련 이슈


## 💡 추가 정보
